### PR TITLE
[MEM-166] Rename Meeshkan to Mem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ workflows:
 jobs: # A basic unit of work in a run
   test-3.6: &test-template
     # directory where steps are run
-    working_directory: ~/meeshkan-examples
+    working_directory: ~/mem-examples
     docker: # run the steps with Docker
       # CircleCI Python images available at: https://hub.docker.com/r/circleci/python/
       - image: circleci/python:3.6.4-stretch

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Meeshkan examples
+# Mem examples
 
 Examples coming soon!

--- a/callbacks_sample/callbacks/counter_sample.py
+++ b/callbacks_sample/callbacks/counter_sample.py
@@ -1,4 +1,4 @@
-from meeshkan.serve.mock.callbacks import callback
+from mem.serve.mock.callbacks import callback
 
 @callback('api.com', 'post', '/counter')
 def counter_callback(request_body, response_body, storage):

--- a/callbacks_sample/callbacks/hello_sample.py
+++ b/callbacks_sample/callbacks/hello_sample.py
@@ -1,4 +1,4 @@
-from meeshkan.serve.mock.callbacks import callback
+from mem.serve.mock.callbacks import callback
 
 
 @callback('api.com', 'get', '/hello', format='plain')

--- a/opbank/callbacks/opbank_callbacks.py
+++ b/opbank/callbacks/opbank_callbacks.py
@@ -1,6 +1,6 @@
 import copy
 
-from meeshkan.serve.mock.callbacks import callback
+from mem.serve.mock.callbacks import callback
 
 
 @callback('sandbox.apis.op-palvelut.fi', 'post', '/v1/payments/initiate', format='json')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
 pytest
-git+https://github.com/meeshkan/meeshkan.git#egg=meeshkan
+git+https://github.com/meeshkan/mem.git#egg=mem

--- a/run_all.py
+++ b/run_all.py
@@ -21,7 +21,7 @@ def wait_mock_server():
 def main():
     for sample in SAMPLES:
         samples_path = os.path.join('.', sample)
-        process_args = ['meeshkan', 'mock', '--callback-dir', 'callbacks']
+        process_args = ['mem', 'mock', '--callback-dir', 'callbacks']
         if 'opbank' == sample:
             process_args.append('specs')
         with subprocess.Popen(process_args, cwd=samples_path) as mock_process:


### PR DESCRIPTION
Blocked by https://github.com/meeshkan/meeshkan/pull/186

As decided in the new product discussions, we will be renaming this product to `Mem` in favor of our new product having the `Meeshkan` name.

For this PR, here are all of the steps I went through:

```bash
git grep -l 'Meeshkan' | xargs sed -i '' -e 's/Meeshkan/Mem/g'
git grep -l 'meeshkan' | xargs sed -i '' -e 's/meeshkan/mem/g'
```

Then I manually went through and fixed some of the changes that are supposed to stay Meeshkan (referencing the company or GitHub org).

Each commit corresponds to those commands. 

Once merged:
- [ ] Rename repo name